### PR TITLE
Fix the build

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.2/apache-maven-3.8.2-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -204,55 +204,55 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.24</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-ejb-client</artifactId>
             <version>1.0.13.Final</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
             <version>1.3.0.GA</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
             <version>1.3.0.GA</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-api</artifactId>
             <version>3.0.0.GA</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.remoting3</groupId>
             <artifactId>jboss-remoting</artifactId>
             <version>3.2.7.GA</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.sasl</groupId>
             <artifactId>jboss-sasl</artifactId>
             <version>1.0.0.Final</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-tomcat-managed-7</artifactId>
             <version>1.1.0.Final</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-tomcat-managed-8</artifactId>
             <version>1.0.1.Final</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,7 @@
         </dependency>
         <!--
             Works around the errors like:
+
              Unable to collect/resolve dependency tree for a resolution due to: Failed to collect dependencies at
              org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
              http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
@@ -241,10 +242,6 @@
             <version>1.0.0.Final</version>
             <scope>test</scope>
         </dependency>
-
-
-
-
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,11 @@
                     <artifactId>arquillian-tomcat-managed-common</artifactId>
                     <version>1.1.0.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-common</artifactId>
+                    <version>1.1.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,19 @@
             <version>1.0.0.CR6</version>
             <scope>test</scope>
         </dependency>
+        <!--
+            Works around the error
+             Unable to collect/resolve dependency tree for a resolution due to: Failed to collect dependencies at
+             org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
+             http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
+        -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.24</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,13 @@
             <name>jboss</name>
             <url>https://repository.jboss.org/nexus/service/local/repositories/snapshots/content</url>
         </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,11 @@
                     <artifactId>arquillian-testenricher-initialcontext</artifactId>
                     <version>1.4.0.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-common</artifactId>
+                    <version>1.0.1.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,12 @@
             <version>1.3.0.GA</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+            <version>1.3.0.GA</version>
+            <scope>test</scope>
+        </dependency>
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,26 @@
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
                     <version>2.2.0.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>10.1.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>11.0.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>12.0.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>13.0.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,82 @@
                     <artifactId>arquillian-testenricher-initialcontext</artifactId>
                     <version>1.3.0.Final</version>
                 </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-spi</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.core</groupId>
+                    <artifactId>arquillian-core-spi</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.core</groupId>
+                    <artifactId>arquillian-core-api</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.config</groupId>
+                    <artifactId>arquillian-config-api</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.config</groupId>
+                    <artifactId>arquillian-config-spi</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.config</groupId>
+                    <artifactId>arquillian-config-impl-base</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.test</groupId>
+                    <artifactId>arquillian-test-api</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.protocol</groupId>
+                    <artifactId>arquillian-protocol-servlet</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-api</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-spi</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-impl-base</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.test</groupId>
+                    <artifactId>arquillian-test-spi</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-cdi</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-resource</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-initialcontext</artifactId>
+                    <version>1.4.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -207,8 +207,9 @@
                     longer supported. But if we include them here, Maven will cache them if they do not already exist,
                     and shinkwrap will uses the cached versions.
 
-                    Make sure to run this on a clean VM before the other profiles are used:
+                    Make sure to run these commands on a clean VM before the other profiles are used:
                     mvn compile -Pshrinkwrap
+                    mvn compile -Pshrinkwrap2
                 -->
                 <dependency>
                     <groupId>org.yaml</groupId>
@@ -432,6 +433,17 @@
                     <version>1.4.0.Final</version>
                 </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>eap6</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,11 +59,8 @@
             </snapshots>
         </repository>
         <repository>
-            <id>spring-plugins</id>
-            <url>https://repo.spring.io/plugins-release/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -164,7 +161,7 @@
             <version>4.4</version>
         </dependency>
         <dependency>
-            <groupId>org.funktionale</groupId>
+            <groupId>com.github.MarioAriasC.funKTionale</groupId>
             <artifactId>funktionale-all</artifactId>
             <version>1.2</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -195,9 +195,9 @@
              org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
              http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
 
-             This occur because the shinkwrap library is set to use an old HTTP maven repo, which is no
-             longer supported. But if we include them here, Maven will cache them if they do not already exist,
-             and shinkwrap will uses the cached versions.
+            This occur because the shinkwrap library is set to use an old HTTP maven repo, which is no
+            longer supported. But if we include them here, Maven will cache them if they do not already exist,
+            and shinkwrap will uses the cached versions.
         -->
         <dependency>
             <groupId>org.yaml</groupId>
@@ -235,7 +235,12 @@
             <version>3.2.7.GA</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.jboss.sasl</groupId>
+            <artifactId>jboss-sasl</artifactId>
+            <version>1.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,11 @@
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
                     <version>2.1.1.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>2.2.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -263,11 +263,6 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>2.1.1.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-managed</artifactId>
                     <version>2.2.0.Final</version>
                 </dependency>
                 <dependency>
@@ -340,7 +335,27 @@
                     <artifactId>arquillian-testenricher-initialcontext</artifactId>
                     <version>1.3.0.Final</version>
                 </dependency>
-
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>shrinkwrap2</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>2.1.1.Final</version>
+                </dependency>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-container-spi</artifactId>
@@ -417,17 +432,6 @@
                     <version>1.4.0.Final</version>
                 </dependency>
             </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skipTests>true</skipTests>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>eap6</id>

--- a/pom.xml
+++ b/pom.xml
@@ -647,14 +647,6 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
-                    <version>2.2.0.Final</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -275,21 +275,6 @@
                     <artifactId>wildfly-dist</artifactId>
                     <version>10.1.0.Final</version>
                 </dependency>
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-dist</artifactId>
-                    <version>11.0.0.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-dist</artifactId>
-                    <version>12.0.0.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-dist</artifactId>
-                    <version>13.0.0.Final</version>
-                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,9 @@
              org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
              http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
 
-             This occure because the chameleon library
+             This occur because the shinkwrap library is set to use an old HTTP maven repo, which is no
+             longer supported. But if we include them here, Maven will cache them if they do not already exist,
+             and shinkwrap will uses the cached versions.
         -->
         <dependency>
             <groupId>org.yaml</groupId>
@@ -227,6 +229,13 @@
             <version>3.0.0.GA</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.remoting3</groupId>
+            <artifactId>jboss-remoting</artifactId>
+            <version>3.2.7.GA</version>
+            <scope>test</scope>
+        </dependency>
+
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -189,62 +189,100 @@
             <version>1.0.0.CR6</version>
             <scope>test</scope>
         </dependency>
-        <!--
-            Works around the errors like:
 
-             Unable to collect/resolve dependency tree for a resolution due to: Failed to collect dependencies at
-             org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
-             http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
-
-            This occur because the shinkwrap library is set to use an old HTTP maven repo, which is no
-            longer supported. But if we include them here, Maven will cache them if they do not already exist,
-            and shinkwrap will uses the cached versions.
-        -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.24</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jboss-ejb-client</artifactId>
-            <version>1.0.13.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.marshalling</groupId>
-            <artifactId>jboss-marshalling</artifactId>
-            <version>1.3.0.GA</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.marshalling</groupId>
-            <artifactId>jboss-marshalling-river</artifactId>
-            <version>1.3.0.GA</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.xnio</groupId>
-            <artifactId>xnio-api</artifactId>
-            <version>3.0.0.GA</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.remoting3</groupId>
-            <artifactId>jboss-remoting</artifactId>
-            <version>3.2.7.GA</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.sasl</groupId>
-            <artifactId>jboss-sasl</artifactId>
-            <version>1.0.0.Final</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>shrinkwrap</id>
+            <dependencies>
+                <!--
+                    Works around the errors like:
+
+                     Unable to collect/resolve dependency tree for a resolution due to: Failed to collect dependencies at
+                     org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
+                     http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
+
+                    This occur because the shinkwrap library is set to use an old HTTP maven repo, which is no
+                    longer supported. But if we include them here, Maven will cache them if they do not already exist,
+                    and shinkwrap will uses the cached versions.
+
+                    Make sure to run this on a clean VM before the other profiles are used:
+                    mvn compile -Pshrinkwrap
+                -->
+                <dependency>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                    <version>1.24</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jboss-ejb-client</artifactId>
+                    <version>1.0.13.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling</artifactId>
+                    <version>1.3.0.GA</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-river</artifactId>
+                    <version>1.3.0.GA</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.xnio</groupId>
+                    <artifactId>xnio-api</artifactId>
+                    <version>3.0.0.GA</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.remoting3</groupId>
+                    <artifactId>jboss-remoting</artifactId>
+                    <version>3.2.7.GA</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.sasl</groupId>
+                    <artifactId>jboss-sasl</artifactId>
+                    <version>1.0.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
+                    <version>2.2.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-8</artifactId>
+                    <version>1.0.1.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-7</artifactId>
+                    <version>1.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>eap6</id>
             <activation>
@@ -447,6 +485,14 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
+                    <version>2.2.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -768,14 +814,6 @@
         </profile>
         <profile>
             <id>tomcat7</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-managed-7</artifactId>
-                    <version>1.1.0.Final</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -810,14 +848,6 @@
         </profile>
         <profile>
             <id>tomcat8</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-managed-8</artifactId>
-                    <version>1.0.1.Final</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -852,14 +882,6 @@
         </profile>
         <profile>
             <id>tomcat85</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-managed-8</artifactId>
-                    <version>1.0.1.Final</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -894,14 +916,6 @@
         </profile>
         <profile>
             <id>tomcat9</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-managed-8</artifactId>
-                    <version>1.0.1.Final</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
             <version>1.0.13.Final</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling</artifactId>
+            <version>1.3.0.GA</version>
+            <scope>test</scope>
+        </dependency>
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,8 @@
              Unable to collect/resolve dependency tree for a resolution due to: Failed to collect dependencies at
              org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
              http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
+
+             This occure because the chameleon library
         -->
         <dependency>
             <groupId>org.yaml</groupId>
@@ -219,6 +221,13 @@
             <version>1.3.0.GA</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>3.0.0.GA</version>
+            <scope>test</scope>
+        </dependency>
+
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,11 @@
                     <artifactId>arquillian-container-spi</artifactId>
                     <version>1.3.0.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-common</artifactId>
+                    <version>1.1.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
                      org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
                      http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
 
-                    This occur because the shinkwrap library is set to use an old HTTP maven repo, which is no
+                    This occurs because the shinkwrap library is set to use an old HTTP maven repo, which is no
                     longer supported. But if we include them here, Maven will cache them if they do not already exist,
                     and shinkwrap will uses the cached versions.
 
@@ -268,6 +268,12 @@
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-managed-7</artifactId>
                     <version>1.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <version>2.1.1.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.octopus</groupId>
     <artifactId>calamari</artifactId>
-    <version>1.0.104</version>
+    <version>1.0.105</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -214,67 +214,56 @@
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
                     <version>1.24</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss</groupId>
                     <artifactId>jboss-ejb-client</artifactId>
                     <version>1.0.13.Final</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.marshalling</groupId>
                     <artifactId>jboss-marshalling</artifactId>
                     <version>1.3.0.GA</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.marshalling</groupId>
                     <artifactId>jboss-marshalling-river</artifactId>
                     <version>1.3.0.GA</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.xnio</groupId>
                     <artifactId>xnio-api</artifactId>
                     <version>3.0.0.GA</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.remoting3</groupId>
                     <artifactId>jboss-remoting</artifactId>
                     <version>3.2.7.GA</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.sasl</groupId>
                     <artifactId>jboss-sasl</artifactId>
                     <version>1.0.0.Final</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
                     <version>2.2.0.Final</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-managed-8</artifactId>
                     <version>1.0.1.Final</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
                     <artifactId>arquillian-tomcat-managed-7</artifactId>
                     <version>1.1.0.Final</version>
-                    <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
                     <version>2.1.1.Final</version>
-                    <scope>test</scope>
                 </dependency>
             </dependencies>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,71 @@
                     <artifactId>wildfly-dist</artifactId>
                     <version>10.1.0.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.core</groupId>
+                    <artifactId>arquillian-core-spi</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.core</groupId>
+                    <artifactId>arquillian-core-api</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.config</groupId>
+                    <artifactId>arquillian-config-api</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.config</groupId>
+                    <artifactId>arquillian-config-impl-base</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.test</groupId>
+                    <artifactId>arquillian-test-api</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.protocol</groupId>
+                    <artifactId>arquillian-protocol-servlet</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-api</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-spi</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-test-impl-base</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.test</groupId>
+                    <artifactId>arquillian-test-spi</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-cdi</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-resource</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-initialcontext</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <main.class>com.octopus.calamari.Main</main.class>
-        <surefire.version>2.20.1</surefire.version>
+        <surefire.version>2.22.2</surefire.version>
         <resources.version>3.0.2</resources.version>
         <compiler.version>3.7.0</compiler.version>
         <shade.version>3.1.0</shade.version>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
             <scope>test</scope>
         </dependency>
         <!--
-            Works around the error
+            Works around the errors like:
              Unable to collect/resolve dependency tree for a resolution due to: Failed to collect dependencies at
              org.yaml:snakeyaml:jar:1.24, caused by: Server returned HTTP response code: 501 for URL:
              http://repo1.maven.org/maven2/org/yaml/snakeyaml/1.24/snakeyaml-1.24.pom
@@ -201,6 +201,13 @@
             <version>1.24</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+            <version>1.0.13.Final</version>
+            <scope>test</scope>
+        </dependency>
+
 
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
                     <artifactId>arquillian-testenricher-initialcontext</artifactId>
                     <version>1.3.0.Final</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-container-spi</artifactId>
+                    <version>1.3.0.Final</version>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,20 @@
             <version>1.0.0.Final</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-tomcat-managed-7</artifactId>
+            <version>1.1.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-tomcat-managed-8</artifactId>
+            <version>1.0.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -204,58 +204,44 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.24</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-ejb-client</artifactId>
             <version>1.0.13.Final</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
             <version>1.3.0.GA</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
             <version>1.3.0.GA</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-api</artifactId>
             <version>3.0.0.GA</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.remoting3</groupId>
             <artifactId>jboss-remoting</artifactId>
             <version>3.2.7.GA</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.sasl</groupId>
             <artifactId>jboss-sasl</artifactId>
             <version>1.0.0.Final</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-tomcat-managed-7</artifactId>
-            <version>1.1.0.Final</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-tomcat-managed-8</artifactId>
-            <version>1.0.1.Final</version>
-            <scope>provided</scope>
-        </dependency>
-
-
     </dependencies>
 
     <profiles>
@@ -782,6 +768,14 @@
         </profile>
         <profile>
             <id>tomcat7</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-7</artifactId>
+                    <version>1.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -816,6 +810,14 @@
         </profile>
         <profile>
             <id>tomcat8</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-8</artifactId>
+                    <version>1.0.1.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -850,6 +852,14 @@
         </profile>
         <profile>
             <id>tomcat85</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-8</artifactId>
+                    <version>1.0.1.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -884,6 +894,14 @@
         </profile>
         <profile>
             <id>tomcat9</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-tomcat-managed-8</artifactId>
+                    <version>1.0.1.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
         <compiler.version>3.7.0</compiler.version>
         <shade.version>3.1.0</shade.version>
         <jar.version>3.0.2</jar.version>
-        <bouncycastle.version>1.62</bouncycastle.version>
-        <wildfly.core.version>8.0.0.Final</wildfly.core.version>
+        <bouncycastle.version>1.69</bouncycastle.version>
+        <wildfly.core.version>16.0.1.Final</wildfly.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <kotlin.version>1.3.41</kotlin.version>
-        <junit.version>4.12.0.redhat-003</junit.version>
+        <kotlin.version>1.5.21</kotlin.version>
+        <junit.version>4.13.2</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <eap.6.version>jboss-eap-6.4</eap.6.version>
         <domain.eap.6.version>domain-jboss-eap-6.4</domain.eap.6.version>
@@ -58,11 +58,6 @@
 
     <repositories>
         <repository>
-            <id>central</id>
-            <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
-        </repository>
-        <repository>
             <id>redhat</id>
             <name>redhat</name>
             <url>https://maven.repository.redhat.com/ga/</url>
@@ -71,14 +66,6 @@
             <id>jboss</id>
             <name>jboss</name>
             <url>https://repository.jboss.org/nexus/service/local/repositories/snapshots/content</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>kotlindev</id>
-            <name>kotlindev</name>
-            <url>https://dl.bintray.com/kotlin/kotlin-dev/</url>
         </repository>
     </repositories>
 
@@ -98,7 +85,7 @@
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>1.3.3</version>
+            <version>2.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -119,7 +106,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
 
         <dependency>
@@ -136,7 +123,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.5.9</version>
+            <version>4.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.threads</groupId>
@@ -161,7 +148,7 @@
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
-            <version>1.2.4.RELEASE</version>
+            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,13 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>spring-plugins</id>
+            <url>https://repo.spring.io/plugins-release/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,23 +45,7 @@
         <tomcat.9.version>tomcat-9.0.0.M26</tomcat.9.version>
     </properties>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>kotlindev</id>
-            <name>kotlindev</name>
-            <url>https://dl.bintray.com/kotlin/kotlin-dev/</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <repositories>
-        <repository>
-            <id>redhat</id>
-            <name>redhat</name>
-            <url>https://maven.repository.redhat.com/ga/</url>
-        </repository>
         <repository>
             <id>jboss</id>
             <name>jboss</name>
@@ -85,7 +69,7 @@
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>2.9.0</version>
+            <version>1.3.3</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -98,9 +82,9 @@
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6.0.redhat-7</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
         </dependency>
 
         <dependency>
@@ -149,6 +133,11 @@
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>
             <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>5.3.9</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/kotlin/com/octopus/calamari/keystore/KeystoreOptions.kt
+++ b/src/main/kotlin/com/octopus/calamari/keystore/KeystoreOptions.kt
@@ -5,8 +5,7 @@ import com.octopus.calamari.options.CERTIFICATE_FILE_NAME
 import com.octopus.calamari.options.CertificateDataClass
 import com.octopus.calamari.utils.Constants
 import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
-import com.octopus.calamari.wildfly.ServerType
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import java.io.File
 import java.lang.IllegalArgumentException
 import java.util.logging.Logger

--- a/src/main/kotlin/com/octopus/calamari/options/CertificateDataClass.kt
+++ b/src/main/kotlin/com/octopus/calamari/options/CertificateDataClass.kt
@@ -5,7 +5,7 @@ import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
 import com.octopus.calamari.utils.impl.FileUtilsImpl
 import com.octopus.calamari.utils.impl.KeystoreUtilsImpl
 import com.octopus.calamari.utils.impl.RetryServiceImpl
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.option.firstOption
 import org.funktionale.option.getOrElse
 import org.funktionale.tries.Try

--- a/src/main/kotlin/com/octopus/calamari/options/WildflyDataClass.kt
+++ b/src/main/kotlin/com/octopus/calamari/options/WildflyDataClass.kt
@@ -1,8 +1,7 @@
 package com.octopus.calamari.options
 
-import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
 import com.octopus.calamari.wildfly.ServerType
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 
 /**
  * The common settings for operations performed on Wildfly

--- a/src/main/kotlin/com/octopus/calamari/tomcat/TomcatDeploy.kt
+++ b/src/main/kotlin/com/octopus/calamari/tomcat/TomcatDeploy.kt
@@ -10,7 +10,7 @@ import com.octopus.calamari.utils.Constants
 import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
 import com.octopus.calamari.utils.impl.LoggingServiceImpl
 import com.octopus.calamari.utils.impl.RetryServiceImpl
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.http.HttpResponse
 import org.apache.http.client.fluent.Request
 import org.apache.http.entity.ContentType

--- a/src/main/kotlin/com/octopus/calamari/tomcat/TomcatOptions.kt
+++ b/src/main/kotlin/com/octopus/calamari/tomcat/TomcatOptions.kt
@@ -2,7 +2,7 @@ package com.octopus.calamari.tomcat
 
 import com.octopus.calamari.utils.Constants
 import org.apache.commons.io.FilenameUtils
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.option.Option
 import java.lang.IllegalArgumentException
 import java.net.URL

--- a/src/main/kotlin/com/octopus/calamari/tomcat/TomcatState.kt
+++ b/src/main/kotlin/com/octopus/calamari/tomcat/TomcatState.kt
@@ -9,7 +9,7 @@ import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
 import com.octopus.calamari.utils.impl.LoggingServiceImpl
 import com.octopus.calamari.utils.impl.RetryServiceImpl
 import org.apache.commons.io.IOUtils
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.http.client.fluent.Request
 import org.funktionale.option.getOrElse
 import org.funktionale.tries.Try

--- a/src/main/kotlin/com/octopus/calamari/tomcathttps/ConfigureTomcat7Connector.kt
+++ b/src/main/kotlin/com/octopus/calamari/tomcathttps/ConfigureTomcat7Connector.kt
@@ -2,7 +2,7 @@ package com.octopus.calamari.tomcathttps
 
 import com.octopus.calamari.extension.addAttribute
 import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.tries.Try
 import org.w3c.dom.Node
 

--- a/src/main/kotlin/com/octopus/calamari/tomcathttps/TomcatHttpsOptions.kt
+++ b/src/main/kotlin/com/octopus/calamari/tomcathttps/TomcatHttpsOptions.kt
@@ -10,7 +10,7 @@ import com.octopus.calamari.utils.Constants
 import com.octopus.calamari.utils.Version
 import com.octopus.calamari.utils.impl.*
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.option.Option
 import org.funktionale.option.getOrElse
 import org.funktionale.tries.Try

--- a/src/main/kotlin/com/octopus/calamari/utils/impl/WildflyService.kt
+++ b/src/main/kotlin/com/octopus/calamari/utils/impl/WildflyService.kt
@@ -7,7 +7,7 @@ import com.octopus.calamari.exception.wildfly.LoginFailException
 import com.octopus.calamari.exception.wildfly.LoginTimeoutException
 import com.octopus.calamari.options.WildflyDataClass
 import com.octopus.calamari.wildflyhttps.WildflyHttpsOptions
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.tries.Try
 import org.jboss.`as`.cli.scriptsupport.CLI
 import org.springframework.retry.RetryCallback

--- a/src/main/kotlin/com/octopus/calamari/wildfly/WildflyDeploy.kt
+++ b/src/main/kotlin/com/octopus/calamari/wildfly/WildflyDeploy.kt
@@ -9,7 +9,7 @@ import com.octopus.calamari.utils.Constants
 import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
 import com.octopus.calamari.utils.impl.LoggingServiceImpl
 import com.octopus.calamari.utils.impl.WildflyService
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.tries.Try
 import java.util.logging.Level
 import java.util.logging.Logger

--- a/src/main/kotlin/com/octopus/calamari/wildfly/WildflyOptions.kt
+++ b/src/main/kotlin/com/octopus/calamari/wildfly/WildflyOptions.kt
@@ -3,9 +3,8 @@ package com.octopus.calamari.wildfly
 import com.octopus.calamari.options.WildflyDataClass
 import com.octopus.calamari.utils.Constants
 import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
-import com.octopus.calamari.wildflyhttps.WildflyHttpsOptions
 import org.apache.commons.io.FilenameUtils
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.tries.Try
 import java.util.logging.Logger
 

--- a/src/main/kotlin/com/octopus/calamari/wildflyhttps/ElytronHttpsConfigurator.kt
+++ b/src/main/kotlin/com/octopus/calamari/wildflyhttps/ElytronHttpsConfigurator.kt
@@ -4,7 +4,7 @@ import com.octopus.calamari.utils.impl.LoggingServiceImpl
 import com.octopus.calamari.utils.impl.RetryServiceImpl
 import com.octopus.calamari.utils.impl.StringUtilsImpl
 import com.octopus.calamari.utils.impl.WildflyService
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.springframework.retry.RetryCallback
 
 /**

--- a/src/main/kotlin/com/octopus/calamari/wildflyhttps/LegacyHttpsConfigurator.kt
+++ b/src/main/kotlin/com/octopus/calamari/wildflyhttps/LegacyHttpsConfigurator.kt
@@ -1,7 +1,7 @@
 package com.octopus.calamari.wildflyhttps
 
 import com.octopus.calamari.utils.impl.*
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.springframework.retry.RetryCallback
 
 /**

--- a/src/main/kotlin/com/octopus/calamari/wildflyhttps/WildflyHttpsConfigurator.kt
+++ b/src/main/kotlin/com/octopus/calamari/wildflyhttps/WildflyHttpsConfigurator.kt
@@ -1,9 +1,6 @@
 package com.octopus.calamari.wildflyhttps
 
-import com.octopus.calamari.utils.impl.StringUtilsImpl
 import com.octopus.calamari.utils.impl.WildflyService
-import org.apache.commons.lang.StringUtils
-
 /**
  * Defines a service for configuring Wildfly HTTPS
  */

--- a/src/main/kotlin/com/octopus/calamari/wildflyhttps/WildflyHttpsOptions.kt
+++ b/src/main/kotlin/com/octopus/calamari/wildflyhttps/WildflyHttpsOptions.kt
@@ -8,7 +8,7 @@ import com.octopus.calamari.options.WildflyDataClass
 import com.octopus.calamari.utils.Constants
 import com.octopus.calamari.utils.impl.ErrorMessageBuilderImpl
 import com.octopus.calamari.wildfly.ServerType
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.funktionale.tries.Try
 import java.io.File
 import java.util.logging.Logger

--- a/src/test/kotlin/com/octopus/calamari/utils/BaseTomcatTest.kt
+++ b/src/test/kotlin/com/octopus/calamari/utils/BaseTomcatTest.kt
@@ -2,7 +2,7 @@ package com.octopus.calamari.utils
 
 import com.octopus.calamari.utils.impl.XMLUtilsImpl
 import org.apache.commons.collections4.iterators.NodeListIterator
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.junit.Assert
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory

--- a/src/test/resources/custom-containers.yaml
+++ b/src/test/resources/custom-containers.yaml
@@ -110,8 +110,8 @@
         jbossHome: ${dist}
         modulePath: ${dist}/modules
   defaultType: managed
-  dist: &WF_DIST
-    coordinates: org.wildfly:wildfly-dist:zip:${version}
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/11.0.0.Final/wildfly-dist-11.0.0.Final.zip
   exclude: &WF11_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -136,7 +136,8 @@
       coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.2.0.Final
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
-  dist: *WF_DIST
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/11.0.0.Final/wildfly-dist-11.0.0.Final.zip
   exclude: &WF11_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -168,8 +169,8 @@
         jbossHome: ${dist}
         modulePath: ${dist}/modules
   defaultType: managed
-  dist: &WF_DIST
-    coordinates: org.wildfly:wildfly-dist:zip:${version}
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/12.0.0.Final/wildfly-dist-12.0.0.Final.zip
   exclude: &WF12_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -194,7 +195,8 @@
       coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.2.0.Final
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
-  dist: *WF_DIST
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/12.0.0.Final/wildfly-dist-12.0.0.Final.zip
   exclude: &WF12_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -226,8 +228,8 @@
         jbossHome: ${dist}
         modulePath: ${dist}/modules
   defaultType: managed
-  dist: &WF_DIST
-    coordinates: org.wildfly:wildfly-dist:zip:${version}
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/12.0.0.Final/wildfly-dist-12.0.0.Final.zip
   exclude: &WF12_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -252,7 +254,8 @@
       coordinates: org.wildfly.arquillian:wildfly-arquillian-container-domain-remote:2.2.0.Final
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
-  dist: *WF_DIST
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/13.0.0.Final/wildfly-dist-13.0.0.Final.zip
   exclude: &WF13_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -284,8 +287,8 @@
         jbossHome: ${dist}
         modulePath: ${dist}/modules
   defaultType: managed
-  dist: &WF_DIST
-    coordinates: org.wildfly:wildfly-dist:zip:${version}
+  dist:
+    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/13.0.0.Final/wildfly-dist-13.0.0.Final.zip
   exclude: &WF13_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*

--- a/src/test/resources/custom-containers.yaml
+++ b/src/test/resources/custom-containers.yaml
@@ -111,7 +111,7 @@
         modulePath: ${dist}/modules
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/11.0.0.Final/wildfly-dist-11.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-11.0.0.Final.zip
   exclude: &WF11_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -137,7 +137,7 @@
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/11.0.0.Final/wildfly-dist-11.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-11.0.0.Final.zip
   exclude: &WF11_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -170,7 +170,7 @@
         modulePath: ${dist}/modules
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/12.0.0.Final/wildfly-dist-12.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-12.0.0.Final.zip
   exclude: &WF12_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -196,7 +196,7 @@
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/12.0.0.Final/wildfly-dist-12.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-12.0.0.Final.zip
   exclude: &WF12_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -229,7 +229,7 @@
         modulePath: ${dist}/modules
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/12.0.0.Final/wildfly-dist-12.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-12.0.0.Final.zip
   exclude: &WF12_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -255,7 +255,7 @@
       adapterClass: org.jboss.as.arquillian.container.domain.remote.RemoteDomainDeployableContainer
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/13.0.0.Final/wildfly-dist-13.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-13.0.0.Final.zip
   exclude: &WF13_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*
@@ -288,7 +288,7 @@
         modulePath: ${dist}/modules
   defaultType: managed
   dist:
-    coordinates: https://repo1.maven.org/maven2/org/wildfly/wildfly-dist/13.0.0.Final/wildfly-dist-13.0.0.Final.zip
+    coordinates: https://s3.amazonaws.com/bamboo-support/wildfly-13.0.0.Final.zip
   exclude: &WF13_EXCLUDE
     - org.jboss.arquillian.test:*
     - org.jboss.arquillian.testenricher:*


### PR DESCRIPTION
Two significant changes have been implemented in the Java ecosystem since this project was last built:

- Maven central required HTTPS
- Bintree shut down

This required a number of changes to the Maven project to get new dependencies and configure new repos. There are no functional changes here, just tidying up libraries and imports.

To run tests in TeamCity, ensure that these commands are run first:

```
mvn compile -Pshrinkwrap
mvn compile -Pshrinkwrap2
```

This will ensure the shrinkwrap dependencies are downloaded by Maven into the cache.